### PR TITLE
Add support for err.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Composer is detected by presence of file `composer.json`. You can force it defin
 
 ## 👨‍💻`now dev`
 
-For running `now dev` properly, you need to have PHP installed on your computer, [learn more](NOW.md).
+For running `now dev` properly, you need to have PHP installed on your computer, [learn more](errors/now-dev-no-local-php.md).
 
 ## 👀 Examples
 

--- a/errors/now-dev-no-local-php.md
+++ b/errors/now-dev-no-local-php.md
@@ -1,8 +1,12 @@
-# NOW
+# It looks like you don't have PHP on your machine.
 
-## How to `now dev`?
+#### Why This Error Occurred
+You ran `now dev` on a machine where PHP is not installed. 
+For the time being, this builder requires a local PHP installation to run the builder locally. 
 
-### Install PHP to your computer
+#### Possible Ways to Fix It
+
+##### Install PHP to your computer
 
 **OSX**
 
@@ -31,20 +35,5 @@ yum update
 yum install php73-cli php73-cgi php73-json php73-curl php73-mbstring
 ```
 
-### Setup minimal project
-
-Create files `index.php` and `now.json`.
-
-```php
-<?php
-phpinfo;
-```
-
-```json
-{
-    "version": 2,
-    "builds": [
-      { "src": "index.php", "use": "now-php@canary" }
-    ]
-  }
-```
+##### Check that php is in the path
+If you do have installed this 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export async function build({
       console.log(`
         It looks like you don't have PHP on your machine.
         Learn more about how to run now dev on your machine.
-        https://github.com/juicyfx/now-php/blob/master/NOW.md
+        https://err.sh/juicyfx/now-php/now-dev-no-local-php
       `)
     }
   }


### PR DESCRIPTION
Maybe it is nice to use err.sh error links as the other ZEIT products do. 

I just added the no local php found error. Feel free to change this PR/ add suggestions. 