### PR TITLE
Show composer output in builder logs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,23 +114,31 @@ async function runComposerInstall(cwd: string) {
       '--no-dev',
       '--no-interaction',
       '--no-scripts',
-      '--ignore-platform-reqs'
+      '--ignore-platform-reqs',
+      '--no-progress'
     ],
+    { stdio: 'inherit' }
   );
 }
 
-async function runPhp(cwd: string, args: any[]) {
+async function runPhp(cwd: string, args: any[], opts = {}) {
   try {
     await spawnAsync(
       'php',
       [`-dextension_dir=${PHP_MODULES_DIR}`, ...args],
       cwd,
       {
-        env: { ...process.env, ...{
-          COMPOSER_HOME: '/tmp',
-          PATH: `${PHP_BIN_DIR}:${process.env.PATH}`,
-          LD_LIBRARY_PATH: `${PHP_LIB_DIR}:/usr/lib64:/lib64:${process.env.LD_LIBRARY_PATH}`
-        }}
+        ...opts,
+        ...{
+        env: {
+          ...process.env,
+          ...{
+            COMPOSER_HOME: '/tmp',
+            PATH: `${PHP_BIN_DIR}:${process.env.PATH}`,
+            LD_LIBRARY_PATH: `${PHP_LIB_DIR}:/usr/lib64:/lib64:${process.env.LD_LIBRARY_PATH}`
+            }
+          }
+        }
       }
     );
   } catch (e) {


### PR DESCRIPTION
This PR shows the composer output. This because I think it is useful, especially when the composer process returns an error or to check the specific version of the installed packages.

Maybe it would be neat to buffer the composer output and only show it on error, but I am not really sure how to do that. I someone does, please describe or add the required changes to this PR.