### PR TITLE
Allow to configure php.ini

### DIFF
--- a/examples/php-ini/index.php
+++ b/examples/php-ini/index.php
@@ -1,0 +1,2 @@
+<?php
+print_r(ini_get_all());

--- a/examples/php-ini/now.json
+++ b/examples/php-ini/now.json
@@ -1,0 +1,26 @@
+{
+    "version": 2,
+    "name": "now-php-ini",
+    "scope": "juicyfx",
+    "regions": [
+        "all"
+    ],
+    "public": true,
+    "builds": [
+        {
+            "src": "*.php",
+            "use": "now-php@experimental",
+            "config": {
+                "php.ini": {
+                    "memory_limit": "128M",
+                    "post_max_size": "32M"
+                }
+            }
+        }
+    ],
+    "build": {
+        "env": {
+            "NOW_PHP_DEBUG": "1"
+        }
+    }
+}

--- a/packages/php/package-lock.json
+++ b/packages/php/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "now-php",
-  "version": "0.0.1-canary.30",
+  "version": "0.0.1-canary.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/php/package.json
+++ b/packages/php/package.json
@@ -1,7 +1,7 @@
 {
   "name": "now-php",
   "description": "PHP Now 2.0 builder for ZEIT Now platform",
-  "version": "0.0.1-canary.30",
+  "version": "0.0.1-canary.31",
   "license": "MIT",
   "main": "./dist/index.js",
   "homepage": "https://github.com/juicyfx/now-php",

--- a/packages/php/src/types.d.ts
+++ b/packages/php/src/types.d.ts
@@ -76,3 +76,7 @@ interface CgiRequest {
 interface Env {
     [k: string]: any,
 }
+
+interface PhpIni {
+    [k: string]: any,
+}

--- a/packages/php/src/utils.ts
+++ b/packages/php/src/utils.ts
@@ -4,6 +4,7 @@ import {
   glob,
   download,
   FileFsRef,
+  FileBlob,
   BuildOptions
 } from '@now/build-utils';
 import { getLibFiles } from "@now-php/lib-73";
@@ -55,6 +56,19 @@ export async function getPhpFiles({ meta }: MetaOptions): Promise<Files> {
 
 export async function getPhpLibFiles(): Promise<Files> {
   return await getLibFiles();
+}
+
+export function modifyPhpIni(phpini: FileBlob, directives: PhpIni): FileBlob {
+  const output: any[] = [];
+  for (const property in directives) {
+    output.push(`${property} = ${directives[property]}`);
+  }
+
+  phpini.data = phpini.data
+    .toString()
+    .concat(output.join("\n"));
+
+  return phpini;
 }
 
 export function getLauncherFiles({ meta }: MetaOptions): Files {


### PR DESCRIPTION
Hi guys! 

Example of now.json with override php.ini.

```json
{
    "version": 2,
    "name": "now-php-ini",
    "scope": "juicyfx",
    "regions": [
        "all"
    ],
    "public": true,
    "builds": [
        {
            "src": "*.php",
            "use": "now-php@experimental",
            "config": {
                "php.ini": {
                    "memory_limit": "128M",
                    "post_max_size": "32M"
                }
            }
        }
    ],
    "build": {
        "env": {
            "NOW_PHP_DEBUG": "1"
        }
    }
}
```

You can configure any php.ini directive under `config['php.ini']`. To test it please use `now-php@experimental`. 

Example of overwritten post_max_size and memory_limit: Take a look at here: https://now-php-ini-f3l1x.juicyfx1.now.sh/

Default ones are: https://now-php-server.juicyfx1.now.sh/