### PR TITLE
Fix typo checking "composer" config option

### DIFF
--- a/packages/php/src/index.ts
+++ b/packages/php/src/index.ts
@@ -37,7 +37,7 @@ export async function build({
   if (!meta.isDev) {
     // Composer is called only if composer.json is provided,
     // or config.composer is TRUE
-    if (includedFiles['composer.json'] || config.compose === true) {
+    if (includedFiles['composer.json'] || config.composer === true) {
       includedFiles = { ...includedFiles, ...await getComposerFiles(workPath) };
     }
   } else {


### PR DESCRIPTION
Unrelated question:

Would it be possible to add an option to change the composer.json path? My project setup looks like this:

```
/now.json
/foo/composer.json
/foo/public/index.php
/bar
```

Looks like you currently assume the `composer.json` to always be in the root, but in my case it's in `/foo` so this is the directory where composer needs to be run. It would be cool if I could pass something like `{ "composerPath": "/foo" }` if this is the case.

Also, reading the code, it looks like I need to manually specify the `includeFiles` option if I don't want to include the `/bar` in my example above in the php lambda, right? Doesn't seem to be documented atm.

(Hope this makes some sense, I'm trying this Now thing for the first time. 🙃)