### PR TITLE
Inherit from process.env for cgi launcher

### DIFF
--- a/packages/php/package.json
+++ b/packages/php/package.json
@@ -1,7 +1,7 @@
 {
   "name": "now-php",
   "description": "PHP Now 2.0 builder for ZEIT Now platform",
-  "version": "0.0.8",
+  "version": "0.0.7",
   "license": "MIT",
   "main": "./dist/index.js",
   "homepage": "https://github.com/juicyfx/now-php",

--- a/packages/php/package.json
+++ b/packages/php/package.json
@@ -1,7 +1,7 @@
 {
   "name": "now-php",
   "description": "PHP Now 2.0 builder for ZEIT Now platform",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "main": "./dist/index.js",
   "homepage": "https://github.com/juicyfx/now-php",

--- a/packages/php/src/launchers/cgi.ts
+++ b/packages/php/src/launchers/cgi.ts
@@ -13,6 +13,7 @@ function createCGIReq({ entrypoint, path, host, method, headers }: CgiInput): Cg
   const { query } = urlParse(path);
 
   const env: Env = {
+    ...process.env,
     SERVER_ROOT: getUserDir(),
     DOCUMENT_ROOT: getUserDir(),
     SERVER_NAME: host,

--- a/packages/php/test/spec/launchers/cgi.js
+++ b/packages/php/test/spec/launchers/cgi.js
@@ -9,6 +9,7 @@ test('create CGI request', () => {
     method: "GET",
     headers: {}
   };
+  process.env.CUSTOM_VALUE = "custom-value";
   const { env } = cgi.createCGIReq(request);
 
   expect(env).toHaveProperty("SERVER_ROOT", "/user");
@@ -28,4 +29,5 @@ test('create CGI request', () => {
   expect(env).toHaveProperty("SERVER_SOFTWARE", 'ZEIT Now PHP');
   expect(env).toHaveProperty("PATH", process.env.PATH);
   expect(env).toHaveProperty("LD_LIBRARY_PATH", process.env.LD_LIBRARY_PATH);
+  expect(env).toHaveProperty("CUSTOM_VALUE", process.env.CUSTOM_VALUE);
 });


### PR DESCRIPTION
# Problem
Environment variables defined in `.env` are not populated when running locally (`now dev`).

## Troubleshooting

The `builtin` launcher uses `process.env` directly ([source][builtin-launcher]), the `cgi` launcher uses a fixed map ([source][cgi-launcher]), `now dev` uses the `cgi` launcher ([source][get-launcher]), so custom environment variables are not applied when running locally.

# Solution
Update the `cgi` launcher to extend from `process.env`.

# Additional Info
My app also uses [vlucas/phpdotenv](https://github.com/vlucas/phpdotenv) but the `.env` file was not appearing in the filesystem. I think this is because `now dev` is accounting for [default ignored files][default-ignore].

`now dev` appears to load the `.env` file ([source][now-dev-dotenv]) and populate `process.env` (which is [sort of documented][custom-runtime-env]), which `now-go` then extends from ([source][now-go-env]).

<!-- `.env` is excluded by default (I think `now dev` takes this into account) -->
[default-ignore]: https://zeit.co/docs/v2/build-step/#ignored-files-and-folders

<!-- `now dev` has built in dotenv support (this mades `now-node` just work) -->
[now-dev-dotenv]: https://github.com/zeit/now/blob/028e023abad7e3b6f4a76e33c5094f91b2b0b731/packages/now-cli/src/util/dev/server.ts#L707-L710

<!-- Custom runtime docs note that environment variables can be access on `process.env` (somewhat cryptically) -->
[custom-runtime-env]: https://github.com/zeit/now/blob/438339258d5461c7af42e9c6025f8f9f9b3c164d/DEVELOPING_A_RUNTIME.md#accessing-environment-and-secrets

<!-- This works "for free" in the node builder, but we can see how node-go extends from `process.env` -->
[now-go-env]: https://github.com/zeit/now/blob/c076a5620fbbd2b747a7c586a8ac68a23fdebf2e/packages/now-go/go-helpers.ts#L110

<!-- `now dev` uses the cgi launcher, which does not inherit from process.env, but the builtin launcher does... -->

[get-launcher]: https://github.com/juicyfx/now-php/blob/0430dc29d79f289ecf099a9bd8992020f6b63c11/packages/php/src/utils.ts#L81-L89
[cgi-launcher]: https://github.com/juicyfx/now-php/blob/0430dc29d79f289ecf099a9bd8992020f6b63c11/packages/php/src/launchers/cgi.ts#L15-L33
[builtin-launcher]: https://github.com/juicyfx/now-php/blob/0430dc29d79f289ecf099a9bd8992020f6b63c11/packages/php/src/launchers/builtin.ts#L27